### PR TITLE
Fixed : Footer links should scroll to the correct sections

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -302,9 +302,9 @@ const Footer = () => {
             bookmark
           </span>
         </li>
-        <li><a href="#features">FEATURES</a></li>
-        <li> <a href="#download">DOWNLOAD</a> </li>
-        <li><a href="#contact">CONTACT</a></li>
+        <li><a target="_blank" href="#features">FEATURES</a></li>
+        <li> <a target="_blank" href="#download">DOWNLOAD</a> </li>
+        <li><a target="_blank" href="#contact">CONTACT</a></li>
         <li className="flex justify-center gap-[40px] ml-auto">
           <Icon className="text-white" icon="dashicons:facebook" width="25px" />
           <Icon

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -302,9 +302,9 @@ const Footer = () => {
             bookmark
           </span>
         </li>
-        <li><a target="_blank" href="#features">FEATURES</a></li>
-        <li> <a target="_blank" href="#download">DOWNLOAD</a> </li>
-        <li><a target="_blank" href="#contact">CONTACT</a></li>
+        <li><a href="/#features">FEATURES</a></li>
+        <li> <a href="/#download">DOWNLOAD</a> </li>
+        <li><a href="/#contact">CONTACT</a></li>
         <li className="flex justify-center gap-[40px] ml-auto">
           <Icon className="text-white" icon="dashicons:facebook" width="25px" />
           <Icon

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,9 +61,9 @@ const Navbar = () => {
       </div>
       <Icon className="lg:hidden" icon="dashicons:menu-alt3" />
       <div className="hidden lg:flex items-center">
-        <a className="text-grayDark text-[13px] link">FEATURES</a>
-        <a className="text-grayDark text-[13px] link">DOWNLOAD</a>
-        <a className="text-grayDark text-[13px] link">CONTACT</a>
+        <a href="#features" className="text-grayDark text-[13px] link">FEATURES</a>
+        <a href="#download" className="text-grayDark text-[13px] link">DOWNLOAD</a>
+        <a href="#contact" className="text-grayDark text-[13px] link">CONTACT</a>
         <button className="w-[111px] h-[40px] bg-salmon text-[13px] link flex items-center justify-center">
           Login
         </button>
@@ -290,7 +290,6 @@ const ContactSection = () => {
 
 const Footer = () => {
   return (
-    // eslint-disable-next-line
     <footer className="w-full py-[40px] bg-[#242a45] flex">
       <ul className="max-w-[1200px] w-full mx-auto md:flex md:flex-row justify-center items-center">
         <li className="flex justify-center items-center mb-[40px] md:mb-0">
@@ -303,9 +302,9 @@ const Footer = () => {
             bookmark
           </span>
         </li>
-        <li><a href="/#features">FEATURES</a></li>
-        <li> <a href="/#download">DOWNLOAD</a> </li>
-        <li><a href="/#contact">CONTACT</a></li>
+        <li><a href="#features">FEATURES</a></li>
+        <li> <a href="#download">DOWNLOAD</a> </li>
+        <li><a href="#contact">CONTACT</a></li>
         <li className="flex justify-center gap-[40px] ml-auto">
           <Icon className="text-white" icon="dashicons:facebook" width="25px" />
           <Icon

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -290,6 +290,7 @@ const ContactSection = () => {
 
 const Footer = () => {
   return (
+    // eslint-disable-next-line
     <footer className="w-full py-[40px] bg-[#242a45] flex">
       <ul className="max-w-[1200px] w-full mx-auto md:flex md:flex-row justify-center items-center">
         <li className="flex justify-center items-center mb-[40px] md:mb-0">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -124,7 +124,7 @@ const HeroSection = () => {
 
 const FeaturesSection = () => {
   return (
-    <section>
+    <section id="features">
       <h2>Features</h2>
       <p className="text-center ">
         Our aim is to make it quick and easy for you to access your favourite
@@ -175,7 +175,7 @@ const BookmarkSection = () => {
 const DownloadSection = () => {
   return (
     <>
-      <section className="mt-[77px]">
+      <section className="mt-[77px]" id="download">
         <h4 className="lg:mt-[150px]">Download the extension</h4>
         <p className="text-center">
           We’ve got more browsers in the pipeline. Please do let us know if
@@ -262,7 +262,7 @@ const FaqSection = () => {
 
 const ContactSection = () => {
   return (
-    <div className="px-[32px] py-[60px] bg-blue">
+    <div className="px-[32px] py-[60px] bg-blue" id="contact">
       <form className="max-w-[442px] mx-auto flex flex-col justify-center">
         <span className="font-medium tracking-[4.61539px] text-[12px] text-white text-center leading-[40px]">
           35,000+ ALREADY JOINED
@@ -302,9 +302,9 @@ const Footer = () => {
             bookmark
           </span>
         </li>
-        <li>FEATURES</li>
-        <li>PRICING</li>
-        <li>CONTACT</li>
+        <li><a href="#features">FEATURES</a></li>
+        <li> <a href="#download">DOWNLOAD</a> </li>
+        <li><a href="#contact">CONTACT</a></li>
         <li className="flex justify-center gap-[40px] ml-auto">
           <Icon className="text-white" icon="dashicons:facebook" width="25px" />
           <Icon


### PR DESCRIPTION
Footer links are now scrolling to the correct sections.  In the footer menu, I changed "**Prices**" to "**Download**". Because currently no pricing section. 